### PR TITLE
add `bundle exec` to serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It can be helpful to preview changes on your computer before opening a pull requ
 
 - Make sure you have ruby installed on your computer. See https://www.ruby-lang.org/en/downloads/
 - `bundle install`
-- `jekyll serve`
+- `bundle exec jekyll serve`
 - Point your browser at http://127.0.0.1:4000/
 
 ## Deployment


### PR DESCRIPTION
so that jekyll launches in the correct gem scope