### PR TITLE
Updated Notion's syntax highlighting feature

### DIFF
--- a/_tools/notion.md
+++ b/_tools/notion.md
@@ -39,7 +39,8 @@ syntax:
   - id: fenced-code-blocks
     available: y
   - id: syntax-highlighting
-    available: n
+    available: p
+    notes: "Must pick the programming language to highlight using the GUI."
   - id: footnotes
     available: n
   - id: heading-ids


### PR DESCRIPTION
Notion now supports syntax highlighting code blocks for plenty of languages.
The only downside is that the only way to pick what language to highlight is using the Notion GUI; you can't indicate a language after the initial three backticks.

![image](https://user-images.githubusercontent.com/38639895/90961120-9f68b480-e474-11ea-8a8d-8c42b322387d.png)

Feel free to change my comment in the `notion.md` file.
