### PR TITLE
Updated Notion's emoji short code feature

### DIFF
--- a/_tools/notion.md
+++ b/_tools/notion.md
@@ -56,7 +56,8 @@ syntax:
   - id: emoji-cp
     available: y
   - id: emoji-sc
-    available: n
+    available: y
+    notes: "The second colon isn't needed. Type `:` followed by the name of the emoji e.g. `:fire`"
   - id: auto-url-linking
     available: y
   - id: disabling-auto-url


### PR DESCRIPTION
Sorry for the second pull request. Notion also supports emoji short code, albeit you don't need to type the second colon. It searched the emoji for you.

![image](https://user-images.githubusercontent.com/38639895/90962602-63871c80-e47f-11ea-8b9e-09bea2bd7028.png)
