### PR TITLE
Added note about Dillinger.io

### DIFF
--- a/_getting-started/how-does-it-work.md
+++ b/_getting-started/how-does-it-work.md
@@ -2,6 +2,8 @@
 
 Dillinger makes writing in Markdown easy because it hides the stuff happening behind the scenes, but it's worth exploring how the process works in general.
 
+**Note**: [Dillinger](https://dillinger.io) is currently down. You can try [StackEdit](https://stackedit.io) (which is another in-browser editor), or just pop a file in your favourite IDE/text editor and save the file with a `.md` or `.markdown` file extension.
+
 When you write in Markdown, the text is stored in a plaintext file that has an `.md` or `.markdown` extension. But then what? How is your Markdown-formatted file converted into HTML or a print-ready document?
 
 The short answer is that you need a *Markdown application* capable of processing the Markdown file. There are lots of applications available — everything from simple scripts to desktop applications that look like Microsoft Word. Despite their visual differences, all of the applications do the same thing. Like Dillinger, they all convert Markdown-formatted text to HTML so it can be displayed in web browsers.


### PR DESCRIPTION
[Dillinger.io](https://dillinger.io) is currently down, so I added a small note explaining its status and included another in-browser Markdown editor.