### PR TITLE
Simplenote footnotes: limit to iOS and macOS

### DIFF
--- a/_tools/simplenote.md
+++ b/_tools/simplenote.md
@@ -38,7 +38,8 @@ syntax:
   - id: syntax-highlighting
     available: n
   - id: footnotes
-    available: y
+    available: p
+    notes: "iOS and macOS only"
   - id: heading-ids
     available: n
   - id: definition-lists


### PR DESCRIPTION
Not available on Android or web; non-exhaustive search of code.