### PR TITLE
Dendron has task lists, heading ids (gfm), footnotes

### DIFF
--- a/_tools/dendron.md
+++ b/_tools/dendron.md
@@ -38,15 +38,15 @@ syntax:
   - id: syntax-highlighting
     available: y
   - id: footnotes
-    available: n
+    available: y
   - id: heading-ids
-    available: n
+    available: y
   - id: definition-lists
     available: n
   - id: strikethrough
     available: y
   - id: task-lists
-    available: n
+    available: y
   - id: emoji-cp
     available: y
   - id: emoji-sc


### PR DESCRIPTION
Dendron has task lists, heading ids, and footers. They each render the same way they do in GitHub Flavored Markdown.

- [Example page with footnotes](https://blog.dendron.so/notes/JzH76BDLaFwJloUFzkGGg/#footnotes)
  - [Docs talking about footnotes](https://wiki.dendron.so/notes/ba97866b-889f-4ac6-86e7-bb2d97f6e376/#footnotes)
- The above two links are example links with heading IDs generated in the format expected from github-flavored markdown
- [Example of task lists (with some checked, some not)](https://wiki.dendron.so/notes/wnjZiTP1UEW9e0aGz1HT0/)

Tasks rendered as expected: 
![image](https://user-images.githubusercontent.com/5951023/138804918-39cba177-bfbd-4f1a-9b91-9b8bb4438d0b.png)
