### PR TITLE
Logseq supports ordered lists

### DIFF
--- a/_tools/logseq.md
+++ b/_tools/logseq.md
@@ -20,7 +20,7 @@ syntax:
   - id: blockquotes
     available: y
   - id: ordered-lists
-    available: n
+    available: y
   - id: unordered-lists
     available: y 
   - id: code


### PR DESCRIPTION
Hi! Thanks for this guide, it's fantastic!

This may be a recent change, but as of right now, it looks like Logseq does in fact support ordered lists! Its block model only works with unordered lists, but _within_ a block's content, Logseq understands ordered lists, at least well enough to give you the next list item number when you press enter after each one.

![CleanShot 2022-10-06 at 12 22 44](https://user-images.githubusercontent.com/2407/194366694-651ee4f0-448e-4723-90f5-948cac5f8d8c.png)
