### PR TITLE
Obsidian Markdown+HTML interaction clarification

### DIFF
--- a/_tools/obsidian.md
+++ b/_tools/obsidian.md
@@ -65,7 +65,7 @@ syntax:
     available: y
   - id: html
     available: p
-    notes: "Some HTML is [sanitized](https://publish.obsidian.md/help/Advanced+topics/HTML+sanitization) for security purposes."
+    notes: "Some HTML is [sanitized](https://publish.obsidian.md/help/Advanced+topics/HTML+sanitization) for security purposes. Markdown inside HTML is frequently left un-parsed."
 see-also:
   - name: Format your notes
     link: https://publish.obsidian.md/help/How+to/Format+your+notes


### PR DESCRIPTION
Markdown inside of HTML elements is frequently (though not always) left un-parsed. I don't think it's worthwhile to go into all the quirks of what will and won't render (stuff like `<span>` elements will render markdown but `<div>`s won't, and neither will in Live Preview, etc.), but I see a lot of people expecting markdown to work inside HTML in Obsidian (as it *should!*) and being very surprised/confused when it doesn't, so I consider the information worth adding.