### PR TITLE
Add Discord support for headings and lists

### DIFF
--- a/_tools/discord.md
+++ b/_tools/discord.md
@@ -6,7 +6,7 @@ icon: discord.png
 website: https://discord.com/
 syntax:
   - id: headings
-    available: n
+    available: y
   - id: paragraphs
     available: n
   - id: line-breaks
@@ -23,14 +23,13 @@ syntax:
   - id: ordered-lists
     available: n
   - id: unordered-lists
-    available: n
+    available: y
   - id: code
     available: y
   - id: horizontal-rules
     available: n
   - id: links
-    available: p
-    notes: "Links are supported in embeds (in fields where Markdown works). Links are also supported in webhook messages and Slash commands."
+    available: y
   - id: images
     available: n
   - id: tables


### PR DESCRIPTION
Discord now supports headings and lists since 4 days ago. Compare before (https://archive.is/hUI6p) and after (https://archive.is/0Oc8S). I noticed this when typing a list on Discord yesterday. This PR updates the article for Discord to state that these features are now supported.

EDIT:
Fixes #159
I don't know what "partially" or "fully supports links" means so I'll just trust @Avakining 's word.