### PR TITLE
Update features table in docusaurus.md

### DIFF
--- a/_tools/docusaurus.md
+++ b/_tools/docusaurus.md
@@ -47,9 +47,9 @@ syntax:
   - id: task-lists
     available: y
   - id: emoji-cp
-    available: u
+    available: y
   - id: emoji-sc
-    available: u
+    available: y
   - id: highlight
     available: n
   - id: subscript

--- a/_tools/docusaurus.md
+++ b/_tools/docusaurus.md
@@ -39,14 +39,13 @@ syntax:
   - id: footnotes
     available: y
   - id: heading-ids
-    available: p
-    notes: "Automatically generated. There's no way to set custom heading IDs."
+    available: y
   - id: definition-lists
     available: n
   - id: strikethrough
     available: y
   - id: task-lists
-    available: n
+    available: y
   - id: emoji-cp
     available: u
   - id: emoji-sc


### PR DESCRIPTION
Docusaurus supports heading id, task lists, and emoji:

- Heading ids: https://docusaurus.io/docs/markdown-features/toc#heading-ids
- Task lists: no link to Docusaurus docs but the task list syntax works:
  ```
  ## Task lists

  - [x] Task 1
  - [ ] Task 2
  - [ ] Task 3
  ```
  This renders to:
  <img width="269" alt="image" src="https://github.com/mattcone/markdown-guide/assets/42832629/cbd8b959-d9b4-426e-93fe-035582f027a4">
- Emoji: both copy/paste and shortcodes. See the [official docs](https://docusaurus.io/docs) and the example:
  ```
  ## Emoji

  Copy: ⚡️

  Shortcode: :fire: :thumbsup:
  ```
  This renders to:
  
  <img width="269" alt="image" src="https://github.com/mattcone/markdown-guide/assets/42832629/249f67ce-3223-4e3f-801a-06305b5d0b80">
