### PR TITLE
Updated discord blockquote syntax

### DIFF
--- a/_tools/discord.md
+++ b/_tools/discord.md
@@ -19,7 +19,7 @@ syntax:
     available: y
   - id: blockquotes
     available: y
-    notes: "You can use `>>>` to create a multi-line blockquote. All text from the `>>>` to the end of the message will be included in the quote."
+    notes: "You can use `>` to create a multi-line blockquote. All text from the `>` to the end of the message will be included in the quote."
   - id: ordered-lists
     available: y
   - id: unordered-lists


### PR DESCRIPTION
Discord's syntax for single line blockquotes is a single `>`, as opposed to the `>>>` in this page, followed by a space, then any text until the end of the **line**.

As stated in [Discord's Markdown article](https://support.discord.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline-#h_01GY0DBAPS5QAB5H7KBXKJZQTB), `>>>` renders the rest of the message as a codeblock. This is less useful in my opinion than just a single line blockquote with `>`, as most of the time it's not really wanted for the entire rest of the message to be a blockquote, instead of one or more lines each prefixed with a `>`.

Because of this, I think the syntax specified should just note the single line blockquotes and could include the ability to use `>>>`, although this might be pushing it with the length of the note.