### PR TITLE
Update discord.md to add "subtext" and reflect linking changes.

### DIFF
--- a/_tools/discord.md
+++ b/_tools/discord.md
@@ -29,8 +29,7 @@ syntax:
   - id: horizontal-rules
     available: n
   - id: links
-    available: p
-    notes: "Not fully supported. See this [GitHub issue](https://github.com/discord/discord-api-docs/issues/6450) for more information."
+    available: y
   - id: images
     available: n
   - id: tables
@@ -98,6 +97,11 @@ As an added bonus, Discord provides support for several obscure elements.
       <td>Underline</td>
       <td><code>__This text will be underlined.__</code></td>
       <td><ins>This text will be underlined.</ins></td>
+    </tr>
+    <tr>
+      <td>Subtext</td>
+      <td><code>-# This line will be made smaller and greyed out.</code></td>
+      <td><small style="opacity: 0.6;">This line will be made smaller and greyed out.</small></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
- Added support for newline "[subtext](https://support.discord.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline#h_01J2HBMKS7587KC8PMAJ47PZR2)" (not to be confused with inline subscript). The entry uses a custom style attribute to somewhat mimic the way the official Discord clients render the element in dark and light modes.
- Marked linking as fully supported as the linked issue is closed and is no longer reproducible on a current official Discord client version. Though may want to consider marking it as partial support as linking doesn't work with emojis, which is [intended behavior](https://github.com/discord/discord-api-docs/issues/6810), likely due to how clicking on emojis already has a behavior assigned to it.