### PR TITLE
automatically generate IDs for H2s on syntax pages

### DIFF
--- a/_includes/syntax.html
+++ b/_includes/syntax.html
@@ -6,7 +6,7 @@
 
 {% for syntax in syntaxes %}
 {% if include.type != "basic-sub" %}
-<h2>{{ syntax.title }}</h2>
+## {{ syntax.title }}
 {% elsif include.type == "basic-sub" %}
 ### {{ syntax.title }}
 {% endif %}


### PR DESCRIPTION
Before, on the [Basic Syntax](view-source:https://www.markdownguide.org/basic-syntax/) page, for example:

```html
<h2>Headings</h2>
```

After:

```html
<h2 id="headings">Headings</h2>
```

Thanks!